### PR TITLE
Fix whitespace other than the space character delimiting the tag name in the opening tag.

### DIFF
--- a/htmltruncate.py
+++ b/htmltruncate.py
@@ -26,6 +26,12 @@ import sys
 
 END = -1
 
+# https://www.w3.org/TR/2011/WD-html5-20110525/common-microsyntaxes.html#space-character
+# The space characters, for the purposes of this specification, are
+# U+0020 SPACE, U+0009 CHARACTER TABULATION (tab), U+000A LINE FEED (LF),
+# U+000C FORM FEED (FF), and U+000D CARRIAGE RETURN (CR).
+HTML_TAG_WHITESPACE_CHARS = ('\u0020', '\u0009', '\u000A', '\u000C', '\u000D')
+
 # HTML5 void-elements that do not require a closing tag
 # https://html.spec.whatwg.org/multipage/syntax.html#void-elements
 VOID_ELEMENTS = ('area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
@@ -96,7 +102,7 @@ class Tokenizer:
         char = self.input[self.counter]
         tag = []
         rest = []
-        while char != '>' and char != ' ':
+        while char != '>' and not char in HTML_TAG_WHITESPACE_CHARS:
             tag.append(char)
             char = self.__next_char()
         while char != '>':

--- a/tests.py
+++ b/tests.py
@@ -44,7 +44,13 @@ class TruncateTest(unittest.TestCase):
               ("<span>This</span> is a test of the truncating features in EDCZ please use <span>with caution</span>", 65,
                "<span>This</span> is a test of the truncating features in EDCZ please use <span>with</span>"),
               ("And this baby right here is the special last line that get's chopped a little shorter", 55,
-               "And this baby right here is the special last line that ") )
+               "And this baby right here is the special last line that "),
+              ("This <span\nclass=\"hello\" id=\"id\">tag</span> is split by a new line just after the tag name", 7,
+               "This <span\nclass=\"hello\" id=\"id\">ta</span>"),
+              ("This <span\nclass=\"hello\" id=\"id\">tag</span> is split by a new line just after the tag name", 17,
+               "This <span\nclass=\"hello\" id=\"id\">tag</span> is split"),
+              ("These tags: <b >space</b>, <b\t>tab</b>, <b\n>LF</b>, <b\r>CR</b>, <b\f>FF</b>, are split by all the admissible whitespace characters just after the tag name", 45,
+               "These tags: <b >space</b>, <b\t>tab</b>, <b\n>LF</b>, <b\r>CR</b>, <b\f>FF</b>, are split") )
 
     def testTruncation(self):
         for input, count, output in self.cases:


### PR DESCRIPTION
First, thanks a lot for this module, that I found in one of your StackOverflow answers. It was exactly what I was looking to avoid writing myself.

I stumbled on a little bug that confused me for a bit. The original HTML that caused it is the following, and it was only a problem when truncating to 221 characters or more, which raised an `UnbalancedError` :

```

<p>Back in San Jose’s historic California Theatre for the first time since 2019, special guests John Ternus, Mike Rockwell, Craig Federighi, and Greg Joswiak join me to discuss the news and announcements from WWDC 2023.</p>

<p><iframe
    width =\"480"  height = "270"
    src = "https://www.youtube.com/embed/DgLrBSQ6x7E"
    title = "YouTube video player"
    frameborder = "0"
    allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
    allowfullscreen>
</iframe></p>

<p><a href="https://www.kolide.com/thetalkshow">Presented by Kolide</a>: The security tool for companies with Okta that need to manage their employees’ devices.</p>

<p>I implore you to watch on the biggest screen you can (or, if you’re in Cupertino, using the biggest <em>virtual</em> screen). We once again shot and mastered the video in 4K, and it looks and sounds terrific. All credit and thanks for that go to my friends at <a href="https://sandwich.co/">Sandwich</a>, who are nothing short of a joy to work with.</p>



    
```

When truncated shorter, it would not throw the error, but have the weird behaviour of altering the closing tag as `</iframe\n>`.

It turned out the tokeniser looks for a space or `>` to delimit the opening tag name, but this `<iframe>` tag has a line feed character instead.

The minimal example to reproduce this behaviour is `<p\n></p>`.

Therefore, this pull request adds support for all the whitespace characters admitted after the tag name, which I found to be space, tab, line feed, carriage return, and form feed, [according to the W3C](https://www.w3.org/TR/2011/WD-html5-20110525/common-microsyntaxes.html#space-character).

I added three test cases. The first one does not throw the error, but the tag is closed wrong. The second one truncates to a longer result and raises the error. The third one tests for all five whitespace characters.